### PR TITLE
Fix: Xcode 12 + RN 0.63.3

### DIFF
--- a/hypertrack-sdk-react-native.podspec
+++ b/hypertrack-sdk-react-native.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage          = package['homepage']
   s.source            = { :git => 'https://github.com/hypertrack/sdk-react-native.git' }
   s.platform          = :ios, '11.0'
-  s.dependency        'React'
+  s.dependency        'React-Core'
   s.dependency        'HyperTrack/Objective-C', '4.5.1'
   s.source_files      = "ios/*.{xcodeproj}", "ios/RNHyperTrack/*.{h,m}"
 end


### PR DESCRIPTION
Update podspec dependency from `React` to `React-Core`, so that Xcode 12 can build latest RN version (0.63.3). See https://github.com/facebook/react-native/issues/29633#issuecomment-694187116 for details