### PR TITLE
Disable Android logging to file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+        resValue("bool",  "logging_to_file_enabled", "false")
     }
     buildTypes {
         release {


### PR DESCRIPTION
Set flag `logging_to_file_enabled` to false, to prevent this kind of crashes:

```
06-02 21:19:35.016 E/FileLog (22301): java.io.IOException: Permission denied
06-02 21:19:35.016 E/FileLog (22301): 	at java.io.UnixFileSystem.createFileExclusively0(Native Method)
06-02 21:19:35.016 E/FileLog (22301): 	at java.io.UnixFileSystem.createFileExclusively(UnixFileSystem.java:317)
06-02 21:19:35.016 E/FileLog (22301): 	at java.io.File.createNewFile(File.java:1008)
06-02 21:19:35.016 E/FileLog (22301): 	at com.hypertrack.sdk.logger.FileLog.open(FileLog.java:47)
06-02 21:19:35.016 E/FileLog (22301): 	at com.hypertrack.sdk.logger.HTLogger.initialize(HTLogger.java:18)
06-02 21:19:35.016 E/FileLog (22301): 	at com.hypertrack.sdk.HyperTrack.initialize(HyperTrack.java:82)
06-02 21:19:35.016 E/FileLog (22301): 	at com.hypertrack.sdk.HyperTrack.initialize(HyperTrack.java:74)
06-02 21:19:35.016 E/FileLog (22301): 	at com.hypertrack.reactnative.androidsdk.HTSDKModule.initialize(HTSDKModule.java:50)
06-02 21:19:35.016 E/FileLog (22301): 	at java.lang.reflect.Method.invoke(Native Method)
```

Refer to https://instaworkteam.slack.com/archives/CTW92G601/p1592393856038700?thread_ts=1592389594.036400&cid=CTW92G601