### PR TITLE
Mention minSdkVersion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For information about how to get started with React Native HyperTrack SDK, pleas
 
 - Gradle version 6.7.1+
 - compileSdkVersion 31+
+- minSdkVersion 21+
 
 ### iOS
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For information about how to get started with React Native HyperTrack SDK, pleas
 
 - Gradle version 6.7.1+
 - compileSdkVersion 31+
-- minSdkVersion 21+
+- minSdkVersion 19+
 
 ### iOS
 


### PR DESCRIPTION
We were missing the `minSdkVersion` in the README.md